### PR TITLE
Update node_helper.js

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -59,7 +59,7 @@ module.exports = NodeHelper.create({
   getIobJson: function (config, callback) {
     var count = 0; // works even for node 0.10
     var result = {};
-    var url = 'http' + (config.https ? 's' : '') + '://' + (config.host || 'localhost') + ':' + (config.port || 8082) + '/state/';
+    var url = 'http' + (config.https ? 's' : '') + '://' + (config.host || 'localhost') + ':' + (config.port || 8082) + '/get/';
     var that = this;
 
     for (var i = 0; i < config.devices.length; i++) {


### PR DESCRIPTION
I swapped 'state' for 'get' so that the values from ioBroker (V. 3.5.10) and the hm-rpc adapter (V. 1.9.2)  are displayed again